### PR TITLE
fixed spike breakdowns containing 24 values instead of 12

### DIFF
--- a/service/servers/serializers.go
+++ b/service/servers/serializers.go
@@ -26,8 +26,8 @@ func serializePriceSeries(series *models.PriceSeries) *proto.PricesSummary {
 
 func serializeBreakdown(breakdown *models.SpikeChanceBreakdown) []float64 {
 	breakdownSerialized := make([]float64, len(breakdown))
-	for _, chance := range breakdown {
-		breakdownSerialized = append(breakdownSerialized, chance)
+	for i, chance := range breakdown {
+		breakdownSerialized[i] = chance
 	}
 	return breakdownSerialized
 }


### PR DESCRIPTION
Closes #1 